### PR TITLE
Sync from private — get-alerts Edge Function + cloud restore + Clear&Rescan fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to FIFA Ticket Scout are documented here. Timestamps are in 
 
 ---
 
+## April 13, 2026
+
+### Fix: Clear & Rescan No Longer Wipes Alerts — 12:00 AM ET
+The "Clear & Rescan" and "Clear Data" buttons on the Scanner tab were silently destroying the user's saved Alerts tab picks (matches, thresholds, category, seats) as a side effect. Root cause: the `CLEAR_DATA` background handler used `chrome.storage.local.clear()` and manually rescued only the `license` key, so any other top-level key (including `alertConfigs` and `visitorId`) got nuked. Replaced the clear-then-restore dance with a surgical `chrome.storage.local.remove("games")` — only the captured scan data is removed, everything else (Alerts picks, license, visitor ID, scan speed preference, filter state) is untouched. Forward-compatible: any future storage key automatically survives by default. Also fixes a silent secondary bug where `visitorId` (the anonymous Supabase attribution key) was being regenerated on every Clear & Rescan, inflating "unique scanners" stats and breaking per-user scan history correlation on the backend.
+
+**Files changed:** `background.js`
+
+---
+
 ## April 12, 2026
 
 ### Alerts Tab — Pro + Web + Alerts Tier — 10:00 PM ET

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to FIFA Ticket Scout are documented here. Timestamps are in 
 
 ## April 13, 2026
 
+### Cloud Restore for Alerts + "Picks Are Final" Warning — 1:00 AM ET
+Added a `get-alerts` Edge Function so the extension can rehydrate the Alerts tab from Supabase whenever the local cache is missing or stale. Previously, if `chrome.storage.local.alertConfigs` was lost (extension reinstall, new browser, new machine, profile switch, Chrome Sync reset, or — until earlier today — a Clear & Rescan click), the Alerts tab would show as empty even though the dispatcher was still firing emails to the user from the server-side `alert_configs` row. Worse, re-saving with a different email would hit the email-lock 403 with no way for the user to recover. Now: every Alerts tab open does a cloud fetch first using the user's license key, falls back to local cache only on network/server failure, and shows a small "⚠ Offline — cached picks" chip in the header when running offline. Server is always the source of truth on conflict; local cache is purely an offline fallback. New `FETCH_ALERTS` message type in the background service worker, mirroring the existing `SAVE_ALERTS` structure (license verify → hash → service-role read on `alert_configs`).
+
+Also added a prominent orange warning banner at the top of the Alerts tab (before first save only) reminding users that match picks are final after saving — only price thresholds can change later. Disappears once `gamesLocked` becomes true so it doesn't nag users who already committed.
+
+**Files changed:** `extension/background.js`, `extension/popup.js`, `extension/popup.css`, `CHANGELOG.md`
+**Files added:** `supabase/functions/get-alerts/index.ts`
+
 ### Fix: Clear & Rescan No Longer Wipes Alerts — 12:00 AM ET
 The "Clear & Rescan" and "Clear Data" buttons on the Scanner tab were silently destroying the user's saved Alerts tab picks (matches, thresholds, category, seats) as a side effect. Root cause: the `CLEAR_DATA` background handler used `chrome.storage.local.clear()` and manually rescued only the `license` key, so any other top-level key (including `alertConfigs` and `visitorId`) got nuked. Replaced the clear-then-restore dance with a surgical `chrome.storage.local.remove("games")` — only the captured scan data is removed, everything else (Alerts picks, license, visitor ID, scan speed preference, filter state) is untouched. Forward-compatible: any future storage key automatically survives by default. Also fixes a silent secondary bug where `visitorId` (the anonymous Supabase attribution key) was being regenerated on every Clear & Rescan, inflating "unique scanners" stats and breaking per-user scan history correlation on the backend.
 

--- a/extension/background.js
+++ b/extension/background.js
@@ -251,13 +251,12 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   }
   if (message.type === "CLEAR_DATA") {
     scannedGames.clear();
-    // Preserve license when clearing scan data
-    chrome.storage.local.get("license", (prev) => {
-      chrome.storage.local.clear(() => {
-        if (prev.license) chrome.storage.local.set({ license: prev.license });
-        sendResponse({ ok: true });
-      });
-    });
+    // Surgical: only wipe the captured-scan data. Everything else
+    // (alertConfigs, license, visitorId, scanSpeed, filters) survives by
+    // default. Avoids the historical "restore the things I forgot to wipe"
+    // footgun where each new top-level storage key had to be added to a
+    // rescue whitelist.
+    chrome.storage.local.remove("games", () => sendResponse({ ok: true }));
     return true;
   }
   if (message.type === "ACTIVATE_LICENSE") {

--- a/extension/background.js
+++ b/extension/background.js
@@ -91,6 +91,42 @@ function syncToSupabase(performanceId, durationMs) {
   });
 }
 
+async function fetchAlerts() {
+  // Cloud rehydrate path. Returns { ok: true, email, games, gamesLocked, savedAt, updatedAt }
+  // on success, or { ok: false, error } on failure. Does NOT write to
+  // chrome.storage.local — the caller decides whether to cache the result
+  // (so an offline fallback path can't accidentally clobber the canonical copy).
+  try {
+    const data = await getStorage();
+    const license = data.license;
+    if (!license?.key) {
+      return { ok: false, error: "No license found." };
+    }
+    if ((license.level || 0) < TIERS.PRO_WEB_ALERTS) {
+      return { ok: false, error: "Alerts requires Pro + Web + Alerts tier." };
+    }
+
+    const resp = await fetch(`${SUPABASE_URL}/functions/v1/get-alerts`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${SUPABASE_ANON_KEY}`,
+        "apikey": SUPABASE_ANON_KEY,
+      },
+      body: JSON.stringify({ licenseKey: license.key }),
+    });
+
+    const result = await resp.json();
+    if (!resp.ok || !result.ok) {
+      return { ok: false, error: result.error || "Fetch failed." };
+    }
+    return result;
+  } catch (err) {
+    console.log("[FIFA Ticket Scout] fetchAlerts error:", err.message);
+    return { ok: false, error: "Could not reach server. Check your connection." };
+  }
+}
+
 async function saveAlerts(payload) {
   try {
     const data = await getStorage();
@@ -271,6 +307,10 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     chrome.storage.local.get("license", (data) => {
       sendResponse({ license: data.license || null });
     });
+    return true;
+  }
+  if (message.type === "FETCH_ALERTS") {
+    fetchAlerts().then(sendResponse);
     return true;
   }
   if (message.type === "SAVE_ALERTS") {

--- a/extension/popup.css
+++ b/extension/popup.css
@@ -193,6 +193,38 @@ body {
   min-width: 0;
 }
 
+.offline-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--gray-600);
+  background: var(--gray-100);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 3px 8px;
+  flex-shrink: 0;
+  cursor: help;
+}
+
+.alerts-warning {
+  margin: 12px 16px 0;
+  padding: 10px 12px;
+  background: #fff7ed;
+  border: 1px solid #fdba74;
+  border-left: 3px solid #ea580c;
+  border-radius: 6px;
+  font-size: 11px;
+  line-height: 1.45;
+  color: #9a3412;
+}
+
+.alerts-warning strong {
+  color: #7c2d12;
+  font-weight: 700;
+}
+
 .alerts-locked {
   padding: 20px 16px;
   text-align: center;

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1025,17 +1025,37 @@ function renderAlertsTab() {
     <div class="alerts-msg">Loading matches&hellip;</div>
   `;
 
-  // Load match list + face values + saved config in parallel
-  Promise.all([fetchMatchList(), fetchFaceValues(), loadSavedAlertConfig()]).then(([matches, faceValues, config]) => {
+  // Load match list + face values + cloud config in parallel.
+  // Cloud is the source of truth; local cache is a fallback when offline.
+  Promise.all([fetchMatchList(), fetchFaceValues(), fetchAlertsFromCloud()]).then(([matches, faceValues, cloudConfig]) => {
     matchList = matches || [];
     faceValueMap = buildFaceValueMap(faceValues || []);
-    if (config?.games) {
-      selectedAlertGames = new Map(
-        config.games.map((g) => [g.match_number, migratePickToNewShape(g)])
-      );
+
+    if (cloudConfig?.ok) {
+      // Canonical: overwrite local cache with the server copy
+      chrome.storage.local.set({ alertConfigs: cloudConfig });
+      if (cloudConfig.games?.length) {
+        selectedAlertGames = new Map(
+          cloudConfig.games.map((g) => [g.match_number, migratePickToNewShape(g)])
+        );
+      }
+      alertsTabLoaded = true;
+      renderAlertsForm(container, cloudConfig);
+      return;
     }
-    alertsTabLoaded = true;
-    renderAlertsForm(container, config);
+
+    // Cloud fetch failed — fall back to whatever's in local cache and
+    // surface an "offline" hint so the user knows they may be looking at
+    // stale data.
+    loadSavedAlertConfig().then((localConfig) => {
+      if (localConfig?.games) {
+        selectedAlertGames = new Map(
+          localConfig.games.map((g) => [g.match_number, migratePickToNewShape(g)])
+        );
+      }
+      alertsTabLoaded = true;
+      renderAlertsForm(container, localConfig, { offline: true });
+    });
   }).catch((err) => {
     container.innerHTML = `
       <div class="alerts-header"><h2>Alerts</h2></div>
@@ -1114,16 +1134,39 @@ function loadSavedAlertConfig() {
   });
 }
 
-function renderAlertsForm(container, savedConfig) {
+// Pull the canonical alert config from Supabase via the get-alerts Edge
+// Function. Returns the config on success, or null on any failure (network,
+// auth, server). The caller is responsible for falling back to the local
+// cache and rendering an offline state.
+function fetchAlertsFromCloud() {
+  return new Promise((resolve) => {
+    chrome.runtime.sendMessage({ type: "FETCH_ALERTS" }, (resp) => {
+      if (chrome.runtime.lastError || !resp?.ok) {
+        resolve(null);
+        return;
+      }
+      resolve(resp);
+    });
+  });
+}
+
+function renderAlertsForm(container, savedConfig, opts) {
   const gamesLocked = savedConfig?.gamesLocked === true;
   const savedEmail = savedConfig?.email || "";
   const count = selectedAlertGames.size;
+  const offline = opts?.offline === true;
 
   container.innerHTML = `
     <div class="alerts-header">
       <h2>Alerts</h2>
       <p class="alerts-subtitle">Pick 3 matches. We'll ping you when prices drop.</p>
+      ${offline ? '<span class="offline-chip" title="Could not reach the server — showing the picks from your last successful save">&#9888; Offline &mdash; cached picks</span>' : ''}
     </div>
+    ${gamesLocked ? '' : `
+    <div class="alerts-warning">
+      <strong>Choose your 3 matches carefully.</strong> Once you hit the <strong>+</strong> button on a match and save, that pick is final &mdash; only the price threshold can change later.
+    </div>
+    `}
 
     ${!savedEmail ? `
     <div class="alerts-section">

--- a/supabase/functions/get-alerts/index.ts
+++ b/supabase/functions/get-alerts/index.ts
@@ -1,0 +1,100 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const supabase = createClient(
+  Deno.env.get("SUPABASE_URL")!,
+  Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!
+);
+
+// Same Pro+Web+Alerts product ID as save-alerts. Only level-30 licenses
+// can read alert configs (no anon access ever — alert_configs has RLS
+// `USING (false)` so the service role is the only way in).
+const ALERTS_PRODUCT_ID = "HEzB2VDD6QMDXaFiynXo5w==";
+const GUMROAD_VERIFY_URL = "https://api.gumroad.com/v2/licenses/verify";
+
+async function sha256(str: string): Promise<string> {
+  const buf = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(str));
+  return Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function jsonResponse(body: any, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+Deno.serve(async (req) => {
+  if (req.method !== "POST") {
+    return jsonResponse({ ok: false, error: "Method not allowed" }, 405);
+  }
+
+  try {
+    const body = await req.json();
+    const { licenseKey } = body;
+
+    if (!licenseKey || typeof licenseKey !== "string") {
+      return jsonResponse({ ok: false, error: "Missing license key" }, 400);
+    }
+
+    // --- Verify license with Gumroad (must be tier 30) ---
+    const verifyResp = await fetch(GUMROAD_VERIFY_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        product_id: ALERTS_PRODUCT_ID,
+        license_key: licenseKey.trim(),
+        increment_uses_count: "false",
+      }),
+    });
+    const verifyResult = await verifyResp.json();
+
+    if (!verifyResult.success) {
+      return jsonResponse(
+        { ok: false, error: "License not valid for Alerts tier" },
+        403
+      );
+    }
+
+    // --- Hash license server-side ---
+    const licenseHash = await sha256(licenseKey.trim());
+
+    // --- Read the user's saved alert config ---
+    const { data: row, error: selectError } = await supabase
+      .from("alert_configs")
+      .select("email, games, games_locked, created_at, updated_at")
+      .eq("license_hash", licenseHash)
+      .maybeSingle();
+
+    if (selectError) {
+      console.error("get-alerts select error:", selectError);
+      return jsonResponse({ ok: false, error: "Read failed" }, 500);
+    }
+
+    if (!row) {
+      // License is valid but user has never saved alerts yet.
+      // Return an empty config so the popup renders the fresh-input form.
+      return jsonResponse({
+        ok: true,
+        email: null,
+        games: [],
+        gamesLocked: false,
+        savedAt: null,
+        updatedAt: null,
+      });
+    }
+
+    return jsonResponse({
+      ok: true,
+      email: row.email,
+      games: row.games || [],
+      gamesLocked: row.games_locked !== false,
+      savedAt: row.created_at ? new Date(row.created_at).getTime() : null,
+      updatedAt: row.updated_at ? new Date(row.updated_at).getTime() : null,
+    });
+  } catch (err) {
+    console.error("get-alerts error:", err);
+    return jsonResponse({ ok: false, error: "Server error" }, 500);
+  }
+});


### PR DESCRIPTION
## Summary

Two commits mirror from private `main`:

- **b71751b** Fix Clear & Rescan wiping saved Alerts + rotating visitor ID
- **ca65db5** Add get-alerts Edge Function + cloud restore path in Alerts tab

## Highlights

### Clear & Rescan surgical fix
The `CLEAR_DATA` handler was using `chrome.storage.local.clear()` + manually rescuing only the `license` key, silently destroying `alertConfigs` and rotating `visitorId` on every click. Replaced with `chrome.storage.local.remove("games")` — surgical, forward-compatible.

### Cloud restore path for Alerts
New `get-alerts` Edge Function lets the extension rehydrate the Alerts tab from Supabase when the local cache is missing or stale. Every Alerts tab open now fetches from cloud first (server is canonical), falls back to local cache on failure with a "⚠ Offline — cached picks" chip in the header.

### Orange "picks are final" warning banner
Prominent banner before first save reminding users that match picks lock to their license after saving. Vanishes once `gamesLocked` becomes true.

See `CHANGELOG.md` for the per-feature breakdown.