### PR TITLE
Sync with private (April 14): ingest salvage, Alerts per-pick lock, 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to FIFA Ticket Scout are documented here. Timestamps are in 
 
 ---
 
+## April 14, 2026
+
+### Alerts Fix: Per-Pick Locking + Centralized MAX_PICKS + 180-Day TTL — 2:30 AM ET
+Fixed the "saved 1 pick, can't add the other 2" bug reported by a Pro + Web + Alerts user. The original lock was per-config (`games_locked` flag at the whole-form level), so saving with any count N < 3 hid the match browser entirely and there was no way to top off the remaining slots. Lock is now **per-pick**: saved matches remain permanent individually (lock icon + threshold-only edit drawer), but the browse section and empty pick slots stay visible whenever total picks < `MAX_PICKS`. New picks added in a later session trigger the same confirm dialog as the original first save and lock once committed. Server-side enforcement added in `save-alerts`: fetches the existing games array on update, rejects any request that drops a locked match or swaps its `performance_id`. Unsaved picks in the current session can still be freely removed via the drawer's "Remove pick" button, which only renders for unlocked picks.
+
+Also centralized the `MAX_PICKS = 3` constant into a new `supabase/functions/_shared/alert_constants.ts` module, imported by both `save-alerts` and `get-alerts`. Both Edge Functions return it as `maxPicks` in their JSON response; the popup reads from there and drives every former literal `3` off it (slot iteration, counter, subtitle, browser visibility check, add-button guard). Changing the per-user pick limit is now one constant edit + `supabase functions deploy` for both functions — the popup auto-syncs on next `loadSavedAlertConfig()` call with zero client rebuild.
+
+Added an `expires_at` column to `alert_configs` with a 180-day SQL default. Set on insert via the column default, never touched on update — adding picks later does not roll the TTL forward. Returned as `expiresAt` (ms epoch) from `get-alerts` for future UI use; popup ignores it for now. Live migration + backfill for existing rows (`expires_at = created_at + interval '180 days'`) ran by hand in the Supabase SQL Editor.
+
+**Files changed:** `extension/popup.js`, `supabase/functions/save-alerts/index.ts`, `supabase/functions/get-alerts/index.ts`, `supabase/schema.sql`
+**Files added:** `supabase/functions/_shared/alert_constants.ts`
+
+### Clarify Scan State in Popup: Stuck-Help + SCANNING/SCANNED Badge — 1:10 AM ET
+Two honesty fixes on the Scanner tab. First: a new "Stuck here?" help block appears on the Scanning empty state, pointing users at the BUY TICKETS → BUY → game workaround for when the seat map page doesn't kick off the API calls the extension needs to start a scan. Subtle purple accent panel under the existing hint, only visible in the Scanning variant of the empty state. Second: the header badge no longer says "LIVE" with a 1.5s pulsing green dot (which falsely implied continuous real-time monitoring). It now flips between **SCANNING** during an active scan and **SCANNED** once the scan status hits `done` or progress reaches 100%, with a static green dot — no animation. State transition reads cleanly: empty-state "Scanning…" → dashboard "SCANNING" badge → "SCANNED" on the final tile. No timer drift, no stale "LIVE" claims while the user is staring at a several-hours-old snapshot.
+
+**Files changed:** `extension/popup.html`, `extension/popup.css`, `extension/popup.js`
+
+### Capture Extra Seat Fields for Preselect Bridge — 1:05 AM ET
+Three more fields added to the per-seat object captured in `background.js` `saveSeats`: `contingentId`, `seatQuality`, and `extent` (the seat polygon's bounding box `[minX, minY, maxX, maxY]`, computed by a new `bboxOf()` helper that walks any nested coordinate array — Point, Polygon, or MultiPolygon). These are the fields the FIFA SPA needs to render a "selected" state when the seat-preselect bridge eventually writes entries into sessionStorage. All three flow through to `scan_snapshots.seats_data` JSONB automatically — no DB schema change, no `ingest-scan` change. The bridge itself remains paused on the blocker of not knowing the live SPA's sessionStorage key yet; this change just gets the data flowing so when the bridge is unblocked, real scan data is already populated in the cloud for testing and field-diffing against hand-picked entries.
+
+**Files changed:** `extension/background.js`
+
+### Salvage Scans on Per-Seat Anomalies — 1:00 AM ET
+Fixed a bug where the `ingest-scan` Edge Function would reject an entire scan (HTTP 400) if any single seat had an out-of-range price, bad `seatId`, or oversized string field. Root cause: the per-seat validation loop at [`index.ts:63-88`](supabase/functions/ingest-scan/index.ts#L63-L88) returned on the first failure instead of skipping the bad seat. New behavior: clamp prices above the Postgres int4 max to `2147483647`, null out sub-$1 or non-numeric prices (the `seats.price` column is already nullable), truncate oversized string fields to 100 chars, and drop seats with bad IDs (primary key — nothing to recover). `MIN_SEAT_COUNT` lowered from 10 to 1 so sold-out matches with only a handful of resale seats still ingest. `MAX_SEAT_COUNT` raised from 15,000 to 50,000 **and** changed from hard-reject to soft-trim — runaway payloads get sliced to the cap with a server-side `console.log` instead of bouncing the whole scan. Top-level structural checks (visitorId format, performanceId format, match name, 50%-same-price anomaly guard) still reject on fail, because those genuinely indicate a broken scan.
+
+Originally diagnosed when David's and his brother-in-law's scans were silently not landing in `scan_snapshots` while everyone else's were. Walked the DevTools service-worker Network tab → saw a 400 on the POST → response body named `"Seat price out of range"` → root caused to a single VIP-tier seat exceeding the previous `MAX_PRICE_MILLICENTS = 100_000_000` (~$100k) cap, which rejected the entire ~10k seat payload. The new cap is the Postgres `int4` column ceiling, not an arbitrary anti-abuse number.
+
+**Files changed:** `supabase/functions/ingest-scan/index.ts`
+
+---
+
 ## April 13, 2026
 
 ### Cloud Restore for Alerts + "Picks Are Final" Warning — 1:00 AM ET

--- a/extension/background.js
+++ b/extension/background.js
@@ -460,6 +460,24 @@ async function saveAvailability(perfId, body, tabId) {
   await chrome.storage.local.set({ games });
 }
 
+// Bounding box of any nested coordinate array (Point, Polygon, MultiPolygon).
+// Returns [minX, minY, maxX, maxY] or undefined if no numeric pairs found.
+function bboxOf(coords) {
+  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+  (function walk(c) {
+    if (!Array.isArray(c) || c.length === 0) return;
+    if (typeof c[0] === "number") {
+      if (c[0] < minX) minX = c[0];
+      if (c[0] > maxX) maxX = c[0];
+      if (c[1] < minY) minY = c[1];
+      if (c[1] > maxY) maxY = c[1];
+      return;
+    }
+    for (const child of c) walk(child);
+  })(coords);
+  return isFinite(minX) ? [minX, minY, maxX, maxY] : undefined;
+}
+
 async function saveSeats(perfId, features, tabId) {
   const data = await getStorage();
   const games = data.games || {};
@@ -493,6 +511,9 @@ async function saveSeats(perfId, features, tabId) {
       tariffId: p.tariffId ?? p.tariff?.id,
       advantageId: p.advantageId ?? p.advantage?.id,
       movementId: p.movementId ?? p.resaleMovementId,
+      contingentId: p.contingentId,
+      seatQuality: p.seatQuality,
+      extent: bboxOf(f.geometry?.coordinates),
     };
   }
 

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "FIFA Ticket Scout",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Real-time price tracking for FIFA World Cup 2026 resale tickets. See every seat, every price, at a glance.",
   "permissions": [
     "storage",

--- a/extension/popup.css
+++ b/extension/popup.css
@@ -1141,12 +1141,6 @@ body {
   height: 6px;
   background: var(--green);
   border-radius: 50%;
-  animation: pulse 1.5s ease-in-out infinite;
-}
-
-@keyframes pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.35; }
 }
 
 /* ---- Empty State ---- */
@@ -1173,6 +1167,23 @@ body {
   line-height: 1.5;
   max-width: 280px;
   margin: 0 auto;
+}
+
+.empty-help {
+  margin: 18px auto 0;
+  max-width: 280px;
+  padding: 10px 14px;
+  background: var(--fifa-purple-dim);
+  border: 1px solid rgba(26, 61, 143, 0.15);
+  border-radius: var(--radius-sm);
+  font-size: 11px;
+  line-height: 1.5;
+  color: var(--gray-700);
+  text-align: left;
+}
+
+.empty-help strong {
+  color: var(--gray-900);
 }
 
 /* ---- Match Info ---- */

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -22,7 +22,7 @@
           <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor"><path d="M9.16 4.945c0-.04.02-.08.06-.1.22-.12 1.86-.84 3.94-.84 1.32 0 2.3.34 2.92.6.14.06.24.08.34.08.18 0 .3-.1.36-.28l.44-1.32c.04-.1.06-.2.06-.28 0-.18-.1-.34-.3-.44C16.3 2.025 14.78 1.505 12.76 1.505c-2.5 0-4.7.88-5.16 1.1-.2.1-.3.24-.3.44v15.5c0 .28.14.44.4.52.7.2 2.44.76 5.06.76 2.28 0 4.04-.48 4.74-.72.2-.06.32-.22.32-.44v-1.56c0-.2-.14-.34-.34-.34-.06 0-.14.02-.22.04-.7.24-2.1.6-3.7.6-2.06 0-3.68-.46-4.14-.62-.04-.02-.06-.04-.06-.08v-5.52c0-.04.02-.06.06-.08.36-.12 1.7-.5 3.54-.5 1.56 0 2.78.32 3.36.52.14.04.24.06.32.06.2 0 .32-.14.32-.36v-1.44c0-.2-.12-.36-.32-.44-.62-.22-1.96-.58-3.68-.58-1.84 0-3.18.38-3.54.5-.04.02-.06 0-.06-.04V4.945z"/></svg>
         </a>
         <span class="badge" id="liveBadge" style="display:none;">
-          <span class="live-dot"></span> LIVE
+          <span class="live-dot"></span> <span id="liveBadgeText">SCANNED</span>
         </span>
       </div>
     </div>
@@ -50,6 +50,9 @@
     </div>
     <p class="empty-title" id="emptyTitle">FIFA Ticket Scout</p>
     <p class="empty-hint" id="emptyHint">Open the FIFA resale ticket site and browse a seat map to start capturing prices.</p>
+    <div class="empty-help" id="scanningHelp" style="display:none;">
+      <p><strong>Stuck here?</strong> If you see this screen for more than 10 seconds, try clicking <strong>BUY TICKETS</strong> in the top right of the FIFA site, then <strong>BUY</strong>, then navigate back to your game.</p>
+    </div>
     <a class="btn btn-small" id="emptyAction" href="#" style="display:none;"></a>
   </div>
 

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -137,15 +137,18 @@ function showEmpty(isFifaSite, isSeatMap) {
   const title = document.getElementById("emptyTitle");
   const hint = document.getElementById("emptyHint");
   const action = document.getElementById("emptyAction");
+  const scanningHelp = document.getElementById("scanningHelp");
 
   if (isSeatMap) {
     title.textContent = "Scanning\u2026";
     hint.textContent = "Capturing seat data from the map. This usually takes a few seconds.";
     action.style.display = "none";
+    scanningHelp.style.display = "block";
   } else if (isFifaSite) {
     title.textContent = "Open a seat map";
     hint.textContent = "You\u2019re on the FIFA ticket site \u2014 select a match and open its seat map to start capturing prices.";
     action.style.display = "none";
+    scanningHelp.style.display = "none";
   } else {
     title.textContent = "FIFA Ticket Scout";
     hint.textContent = "Open the FIFA resale ticket site and browse a seat map to start capturing prices.";
@@ -155,6 +158,7 @@ function showEmpty(isFifaSite, isSeatMap) {
       e.preventDefault();
       chrome.tabs.create({ url: "https://fwc26-resale-usd.tickets.fifa.com" });
     };
+    scanningHelp.style.display = "none";
   }
 }
 
@@ -1829,6 +1833,12 @@ function updateScanProgress(perfId, completed, total, status, eta) {
   if (perfId && currentPerfId && perfId !== currentPerfId) return;
   const pct = Math.round((completed / total) * 100);
   document.getElementById("progressFill").style.width = pct + "%";
+
+  // Header badge: SCANNING while in progress, SCANNED once done.
+  const badgeText = document.getElementById("liveBadgeText");
+  if (badgeText) {
+    badgeText.textContent = (status === "done" || pct >= 100) ? "SCANNED" : "SCANNING";
+  }
 
   // Track scan timing
   if (pct > 0 && scanStartTime === 0) scanStartTime = Date.now();

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -995,6 +995,22 @@ let faceValueMap = {}; // match_number -> { cat1, cat2, cat3 }
 let selectedAlertGames = new Map(); // match_number -> prefs
 let alertFilters = { search: "", stages: new Set(["All"]), countries: new Set() };
 let expandedDrawer = null; // match_number of currently open drawer
+// Pick limit + per-pick lock state. Both come from the get-alerts response on
+// every render so the server is the single source of truth for MAX_PICKS;
+// fallback default is 3 if the server response hasn't loaded yet.
+let maxPicks = 3;
+let lockedMatchNumbers = new Set(); // match_numbers that came from saved config
+
+function isPickLocked(matchNumber) {
+  return lockedMatchNumbers.has(matchNumber);
+}
+
+function hasAnyUnlockedPick() {
+  for (const pick of selectedAlertGames.values()) {
+    if (!isPickLocked(pick.match_number)) return true;
+  }
+  return false;
+}
 
 // City → host country
 const CITY_COUNTRY = {
@@ -1024,7 +1040,7 @@ function renderAlertsTab() {
   container.innerHTML = `
     <div class="alerts-header">
       <h2>Alerts</h2>
-      <p class="alerts-subtitle">Pick 3 matches. We'll ping you when prices drop.</p>
+      <p class="alerts-subtitle">Pick ${maxPicks} matches. We'll ping you when prices drop.</p>
     </div>
     <div class="alerts-msg">Loading matches&hellip;</div>
   `;
@@ -1155,22 +1171,29 @@ function fetchAlertsFromCloud() {
 }
 
 function renderAlertsForm(container, savedConfig, opts) {
-  const gamesLocked = savedConfig?.gamesLocked === true;
+  // Pull MAX_PICKS from the server response (fallback to current value).
+  // Build the per-pick lock set from the saved config — a pick is "locked"
+  // if it was already in the saved config when this form rendered.
+  if (typeof savedConfig?.maxPicks === "number") maxPicks = savedConfig.maxPicks;
+  lockedMatchNumbers = new Set((savedConfig?.games || []).map((g) => g.match_number));
+
   const savedEmail = savedConfig?.email || "";
   const count = selectedAlertGames.size;
+  const slotsAvailable = count < maxPicks;
+  const hasUnlocked = hasAnyUnlockedPick();
   const offline = opts?.offline === true;
 
   container.innerHTML = `
     <div class="alerts-header">
       <h2>Alerts</h2>
-      <p class="alerts-subtitle">Pick 3 matches. We'll ping you when prices drop.</p>
+      <p class="alerts-subtitle">Pick ${maxPicks} matches. We'll ping you when prices drop.</p>
       ${offline ? '<span class="offline-chip" title="Could not reach the server — showing the picks from your last successful save">&#9888; Offline &mdash; cached picks</span>' : ''}
     </div>
-    ${gamesLocked ? '' : `
+    ${slotsAvailable ? `
     <div class="alerts-warning">
-      <strong>Choose your 3 matches carefully.</strong> Once you hit the <strong>+</strong> button on a match and save, that pick is final &mdash; only the price threshold can change later.
+      <strong>Choose your matches carefully.</strong> Once you hit the <strong>+</strong> button on a match and save, that pick is final &mdash; only the price threshold can change later.
     </div>
-    `}
+    ` : ''}
 
     ${!savedEmail ? `
     <div class="alerts-section">
@@ -1192,12 +1215,12 @@ function renderAlertsForm(container, savedConfig, opts) {
     <div class="picks-section">
       <div class="picks-header">
         <span class="picks-title">Your Picks</span>
-        <span class="picks-counter">${count} of 3${gamesLocked ? ' &middot; Locked' : ''}</span>
+        <span class="picks-counter">${count} of ${maxPicks}</span>
       </div>
       <div id="pickSlots"></div>
     </div>
 
-    ${!gamesLocked ? `
+    ${slotsAvailable ? `
     <!-- Browse -->
     <div class="alerts-browse">
       <input type="text" id="alertsSearch" class="alerts-search" placeholder="Search team, city, or stage..." value="${escapeHtml(alertFilters.search)}">
@@ -1210,13 +1233,13 @@ function renderAlertsForm(container, savedConfig, opts) {
 
     <div id="alertsMsg"></div>
 
-    <button class="btn-save-alerts" id="saveAlertsBtn" ${count === 0 && !gamesLocked ? "disabled" : ""}>
-      ${gamesLocked ? "Update Price Thresholds" : `Save my ${count > 0 ? count : ""} pick${count !== 1 ? "s" : ""}`}
+    <button class="btn-save-alerts" id="saveAlertsBtn" ${count === 0 ? "disabled" : ""}>
+      ${hasUnlocked ? `Save my ${count} pick${count !== 1 ? "s" : ""}` : "Update Price Thresholds"}
     </button>
   `;
 
-  renderPickSlots(gamesLocked);
-  if (!gamesLocked) {
+  renderPickSlots();
+  if (slotsAvailable) {
     renderFilterPills();
     renderMatchList();
     document.getElementById("alertsSearch").addEventListener("input", (e) => {
@@ -1227,17 +1250,17 @@ function renderAlertsForm(container, savedConfig, opts) {
   document.getElementById("saveAlertsBtn").addEventListener("click", handleSaveAlerts);
 }
 
-function renderPickSlots(gamesLocked) {
+function renderPickSlots() {
   const slotsEl = document.getElementById("pickSlots");
-  const slots = [1, 2, 3];
+  const slots = Array.from({ length: maxPicks }, (_, i) => i + 1);
   const picks = Array.from(selectedAlertGames.values());
 
   slotsEl.innerHTML = slots.map((n) => {
     const pick = picks[n - 1];
     if (!pick) {
-      if (gamesLocked) return "";
       return `<div class="pick-slot pick-slot-empty">+ Add pick ${n}</div>`;
     }
+    const locked = isPickLocked(pick.match_number);
     const match = matchList.find((m) => m.match_number === pick.match_number);
     if (!match) return "";
     const teams = (match.home_team && match.away_team)
@@ -1251,13 +1274,13 @@ function renderPickSlots(gamesLocked) {
       <div class="pick-slot ${isExpanded ? 'expanded' : ''}" data-match="${pick.match_number}">
         <div class="pick-slot-header">
           <div class="pick-slot-info">
-            <div class="pick-slot-teams">#${pick.match_number} &middot; ${escapeHtml(teams)} ${gamesLocked ? '<span class="lock-inline">&#x1F512;</span>' : ''}</div>
+            <div class="pick-slot-teams">#${pick.match_number} &middot; ${escapeHtml(teams)} ${locked ? '<span class="lock-inline">&#x1F512;</span>' : ''}</div>
             <div class="pick-slot-meta">${escapeHtml(match.city || "")} &middot; ${escapeHtml(match.stage || "")} &middot; ${dateStr}</div>
             <div class="pick-summary">${summary}</div>
           </div>
           <button class="pick-edit-btn" data-edit="${pick.match_number}">${isExpanded ? 'Close' : 'Edit'}</button>
         </div>
-        ${isExpanded ? renderThresholdDrawer(pick, gamesLocked) : ""}
+        ${isExpanded ? renderThresholdDrawer(pick, locked) : ""}
       </div>
     `;
   }).join("");
@@ -1268,12 +1291,12 @@ function renderPickSlots(gamesLocked) {
       e.stopPropagation();
       const matchNum = parseInt(btn.dataset.edit);
       expandedDrawer = expandedDrawer === matchNum ? null : matchNum;
-      renderPickSlots(gamesLocked);
+      renderPickSlots();
     });
   });
 
   // Wire up drawer inputs
-  wireThresholdDrawer(gamesLocked);
+  wireThresholdDrawer();
 }
 
 // Normalize a saved game config into the current pref shape.
@@ -1425,7 +1448,7 @@ function sliderLabelForMode(pick) {
   return formatPercentLabel(pick.percentOfFace || 0);
 }
 
-function renderThresholdDrawer(pick, gamesLocked) {
+function renderThresholdDrawer(pick, locked) {
   const category = pick.category || "any";
   const seats = pick.seats || 2;
   const mode = pick.thresholdMode || "percent";
@@ -1473,7 +1496,7 @@ function renderThresholdDrawer(pick, gamesLocked) {
         <button class="step-btn" data-step="+1">+</button>
       </div>
 
-      ${!gamesLocked ? `
+      ${!locked ? `
       <div class="drawer-actions">
         <button class="drawer-remove" data-remove="${pick.match_number}">Remove pick</button>
       </div>
@@ -1482,7 +1505,7 @@ function renderThresholdDrawer(pick, gamesLocked) {
   `;
 }
 
-function wireThresholdDrawer(gamesLocked) {
+function wireThresholdDrawer() {
   document.querySelectorAll(".threshold-drawer").forEach((drawer) => {
     const matchNum = parseInt(drawer.dataset.match);
     const prefs = selectedAlertGames.get(matchNum);
@@ -1501,7 +1524,7 @@ function wireThresholdDrawer(gamesLocked) {
           if (fv != null) prefs.absolute = fv;
         }
         selectedAlertGames.set(matchNum, prefs);
-        renderPickSlots(gamesLocked);
+        renderPickSlots();
       });
     });
 
@@ -1526,7 +1549,7 @@ function wireThresholdDrawer(gamesLocked) {
         const cfg = sliderConfigForMode(mode);
         slider.style.setProperty("--fill", sliderFillPct(v, cfg.min, cfg.max) + "%");
       });
-      slider.addEventListener("change", () => renderPickSlots(gamesLocked));
+      slider.addEventListener("change", () => renderPickSlots());
     }
 
     // Category pills
@@ -1535,7 +1558,7 @@ function wireThresholdDrawer(gamesLocked) {
         e.stopPropagation();
         prefs.category = btn.dataset.cat;
         selectedAlertGames.set(matchNum, prefs);
-        renderPickSlots(gamesLocked);
+        renderPickSlots();
       });
     });
 
@@ -1547,7 +1570,7 @@ function wireThresholdDrawer(gamesLocked) {
         const next = Math.max(1, Math.min(6, (prefs.seats || 2) + delta));
         prefs.seats = next;
         selectedAlertGames.set(matchNum, prefs);
-        renderPickSlots(gamesLocked);
+        renderPickSlots();
       });
     });
 
@@ -1643,7 +1666,7 @@ function renderMatchList() {
 
   const filtered = filterMatches();
   const count = selectedAlertGames.size;
-  const canAdd = count < 3;
+  const canAdd = count < maxPicks;
 
   headerEl.innerHTML = `Showing ${filtered.length} of ${matchList.length}`;
 
@@ -1677,7 +1700,7 @@ function renderMatchList() {
       e.stopPropagation();
       const matchNum = parseInt(btn.dataset.add);
       if (selectedAlertGames.has(matchNum)) return;
-      if (selectedAlertGames.size >= 3) return;
+      if (selectedAlertGames.size >= maxPicks) return;
       addGameSelection(matchNum);
     });
   });
@@ -1723,20 +1746,23 @@ function handleSaveAlerts() {
   const emailInput = document.getElementById("alertsEmail");
 
   loadSavedAlertConfig().then((config) => {
-    const gamesLocked = config?.gamesLocked === true;
-    const email = config?.email || (emailInput ? emailInput.value.trim() : "");
+    const savedEmail = config?.email || "";
+    const email = savedEmail || (emailInput ? emailInput.value.trim() : "");
 
-    // Validate email (only if not locked)
-    if (!gamesLocked) {
-      if (!validEmail(email)) {
-        msgEl.innerHTML = '<div class="alerts-msg error">Please enter a single valid email address.</div>';
-        return;
-      }
-      if (selectedAlertGames.size === 0) {
-        msgEl.innerHTML = '<div class="alerts-msg error">Pick at least one game.</div>';
-        return;
-      }
-      // Pre-save confirmation
+    // Email validation only when there's no saved one yet
+    if (!savedEmail && !validEmail(email)) {
+      msgEl.innerHTML = '<div class="alerts-msg error">Please enter a single valid email address.</div>';
+      return;
+    }
+
+    if (selectedAlertGames.size === 0) {
+      msgEl.innerHTML = '<div class="alerts-msg error">Pick at least one game.</div>';
+      return;
+    }
+
+    // Confirm only when we're about to lock at least one NEW pick.
+    // Threshold-only updates (all picks already locked) skip the dialog.
+    if (hasAnyUnlockedPick()) {
       const confirmed = confirm(
         "Lock in these matches?\n\n" +
         "To keep alerts for true fans, the matches you pick are permanent.\n\n" +
@@ -1777,13 +1803,13 @@ function handleSaveAlerts() {
       { type: "SAVE_ALERTS", payload: { email, games } },
       (resp) => {
         if (resp?.ok) {
-          msgEl.innerHTML = '<div class="alerts-msg success">Locked in. We\'re watching these for you.</div>';
+          msgEl.innerHTML = '<div class="alerts-msg success">Saved. We\'re watching these for you.</div>';
           alertsTabLoaded = false; // force reload on next open
           setTimeout(() => renderAlertsTab(), 600);
         } else {
           msgEl.innerHTML = `<div class="alerts-msg error">${resp?.error || "Save failed. Try again."}</div>`;
           btn.disabled = false;
-          btn.textContent = gamesLocked ? "Update Price Thresholds" : "Save my picks";
+          btn.textContent = hasAnyUnlockedPick() ? "Save my picks" : "Update Price Thresholds";
         }
       }
     );

--- a/supabase/functions/_shared/alert_constants.ts
+++ b/supabase/functions/_shared/alert_constants.ts
@@ -1,0 +1,17 @@
+// Single source of truth for alert config limits.
+// Imported by save-alerts and get-alerts. Both functions return MAX_PICKS in
+// their JSON responses so the popup never has to hardcode it.
+//
+// To change the per-user pick limit:
+//   1. Edit MAX_PICKS below
+//   2. supabase functions deploy save-alerts
+//   3. supabase functions deploy get-alerts
+//   4. Existing extension installs auto-pick-up via get-alerts response.
+//
+// EXPIRES_DAYS is reserved — currently the alert_configs.expires_at column
+// has its own SQL DEFAULT (now() + interval '180 days'). If a future change
+// wants the Edge Function to set expires_at explicitly on insert, this is
+// where the value lives.
+
+export const MAX_PICKS = 3;
+export const EXPIRES_DAYS = 180;

--- a/supabase/functions/get-alerts/index.ts
+++ b/supabase/functions/get-alerts/index.ts
@@ -1,4 +1,5 @@
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { MAX_PICKS } from "../_shared/alert_constants.ts";
 
 const supabase = createClient(
   Deno.env.get("SUPABASE_URL")!,
@@ -63,7 +64,7 @@ Deno.serve(async (req) => {
     // --- Read the user's saved alert config ---
     const { data: row, error: selectError } = await supabase
       .from("alert_configs")
-      .select("email, games, games_locked, created_at, updated_at")
+      .select("email, games, games_locked, created_at, updated_at, expires_at")
       .eq("license_hash", licenseHash)
       .maybeSingle();
 
@@ -82,6 +83,8 @@ Deno.serve(async (req) => {
         gamesLocked: false,
         savedAt: null,
         updatedAt: null,
+        expiresAt: null,
+        maxPicks: MAX_PICKS,
       });
     }
 
@@ -92,6 +95,8 @@ Deno.serve(async (req) => {
       gamesLocked: row.games_locked !== false,
       savedAt: row.created_at ? new Date(row.created_at).getTime() : null,
       updatedAt: row.updated_at ? new Date(row.updated_at).getTime() : null,
+      expiresAt: row.expires_at ? new Date(row.expires_at).getTime() : null,
+      maxPicks: MAX_PICKS,
     });
   } catch (err) {
     console.error("get-alerts error:", err);

--- a/supabase/functions/ingest-scan/index.ts
+++ b/supabase/functions/ingest-scan/index.ts
@@ -9,10 +9,10 @@ const supabase = createClient(
 const VISITOR_ID_RE = /^[a-f0-9]{32}$/i;
 const PERFORMANCE_ID_RE = /^\d{5,20}$/;
 const RATE_LIMIT_PER_MINUTE = 10;
-const MIN_SEAT_COUNT = 10;
-const MAX_SEAT_COUNT = 15000;
+const MIN_SEAT_COUNT = 1;
+const MAX_SEAT_COUNT = 50000;
 const MIN_PRICE_MILLICENTS = 1000;        // ~$1
-const MAX_PRICE_MILLICENTS = 100000000;   // ~$100k
+const MAX_PRICE_MILLICENTS = 2147483647;  // int4 max (~$2.1M) — Postgres `seats.price` is int4, so this is the real ceiling
 const MAX_FIELD_LENGTH = 100;
 
 function jsonResponse(body: any, status = 200) {
@@ -46,12 +46,17 @@ Deno.serve(async (req) => {
       return jsonResponse({ ok: false, error: "Invalid seats payload" }, 400);
     }
 
-    const seatEntries = Object.entries(seats);
-    if (seatEntries.length < MIN_SEAT_COUNT || seatEntries.length > MAX_SEAT_COUNT) {
+    let seatEntries = Object.entries(seats);
+    if (seatEntries.length < MIN_SEAT_COUNT) {
       return jsonResponse(
-        { ok: false, error: `Seat count must be between ${MIN_SEAT_COUNT} and ${MAX_SEAT_COUNT}` },
+        { ok: false, error: `Seat count below ${MIN_SEAT_COUNT}` },
         400
       );
+    }
+    // Soft cap: trim runaway payloads instead of rejecting.
+    if (seatEntries.length > MAX_SEAT_COUNT) {
+      console.log(`ingest-scan: trimmed ${seatEntries.length - MAX_SEAT_COUNT} seats over cap (perf=${performanceId})`);
+      seatEntries = seatEntries.slice(0, MAX_SEAT_COUNT);
     }
 
     // --- Match name validation (must look like FIFA data) ---
@@ -60,31 +65,59 @@ Deno.serve(async (req) => {
       return jsonResponse({ ok: false, error: "Invalid match name" }, 400);
     }
 
-    // --- Per-seat validation ---
+    // --- Per-seat cleaning: salvage the scan, don't reject it over single-seat anomalies. ---
+    // Price: clamp high, null low/non-numeric (Postgres `seats.price` is nullable).
+    // Oversized string fields: truncate. Bad seatId (primary key): drop the seat.
     const priceCounts: Record<string, number> = {};
+    const cleanedSeats: Record<string, any> = {};
+    let droppedSeats = 0;
+
     for (const [seatId, s] of seatEntries) {
       const seat = s as any;
       if (typeof seatId !== "string" || seatId.length > MAX_FIELD_LENGTH) {
-        return jsonResponse({ ok: false, error: "Invalid seat ID" }, 400);
+        droppedSeats++;
+        continue;
       }
-      if (typeof seat.price !== "number" || seat.price < MIN_PRICE_MILLICENTS || seat.price > MAX_PRICE_MILLICENTS) {
-        return jsonResponse({ ok: false, error: "Seat price out of range" }, 400);
+
+      let price: number | null = null;
+      if (typeof seat.price === "number" && Number.isFinite(seat.price)) {
+        if (seat.price > MAX_PRICE_MILLICENTS) price = MAX_PRICE_MILLICENTS;
+        else if (seat.price >= MIN_PRICE_MILLICENTS) price = seat.price;
       }
-      // Field length checks
+
+      const cleaned: any = { ...seat, price };
       for (const field of ["block", "area", "row", "seat", "category"]) {
         const val = seat[field];
-        if (val != null && (typeof val !== "string" || val.length > MAX_FIELD_LENGTH)) {
-          return jsonResponse({ ok: false, error: `Invalid seat.${field}` }, 400);
+        if (typeof val === "string" && val.length > MAX_FIELD_LENGTH) {
+          cleaned[field] = val.slice(0, MAX_FIELD_LENGTH);
         }
       }
-      // Track price frequency
-      priceCounts[seat.price] = (priceCounts[seat.price] || 0) + 1;
+
+      cleanedSeats[seatId] = cleaned;
+      if (price !== null) {
+        priceCounts[price] = (priceCounts[price] || 0) + 1;
+      }
+    }
+
+    const cleanedEntries = Object.entries(cleanedSeats);
+    if (cleanedEntries.length < MIN_SEAT_COUNT) {
+      return jsonResponse(
+        { ok: false, error: `Seat count after cleaning below ${MIN_SEAT_COUNT}` },
+        400
+      );
+    }
+
+    if (droppedSeats > 0) {
+      console.log(`ingest-scan: dropped ${droppedSeats} seats with bad IDs (perf=${performanceId})`);
     }
 
     // Reject if >50% of seats have the same price (synthetic data)
-    const maxSamePrice = Math.max(...Object.values(priceCounts));
-    if (maxSamePrice / seatEntries.length > 0.5) {
-      return jsonResponse({ ok: false, error: "Suspicious price distribution" }, 400);
+    const priceValues = Object.values(priceCounts);
+    if (priceValues.length > 0) {
+      const maxSamePrice = Math.max(...priceValues);
+      if (maxSamePrice / cleanedEntries.length > 0.5) {
+        return jsonResponse({ ok: false, error: "Suspicious price distribution" }, 400);
+      }
     }
 
     // --- Rate limiting per visitor_id ---
@@ -107,8 +140,8 @@ Deno.serve(async (req) => {
       performance_id: performanceId,
       visitor_id: visitorId,
       license_hash: licenseHash || null,
-      seat_count: seatEntries.length,
-      seats_data: seats,
+      seat_count: cleanedEntries.length,
+      seats_data: cleanedSeats,
       currency: match?.currency || "USD",
       match_name: match?.name || null,
       match_date: match?.date || null,
@@ -129,7 +162,7 @@ Deno.serve(async (req) => {
     }
 
     const now = new Date().toISOString();
-    const seatRows = seatEntries.map(([seatId, s]: [string, any]) => ({
+    const seatRows = cleanedEntries.map(([seatId, s]: [string, any]) => ({
       performance_id: performanceId,
       seat_id: seatId,
       block: s.block || null,

--- a/supabase/functions/save-alerts/index.ts
+++ b/supabase/functions/save-alerts/index.ts
@@ -1,4 +1,5 @@
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { MAX_PICKS } from "../_shared/alert_constants.ts";
 
 const supabase = createClient(
   Deno.env.get("SUPABASE_URL")!,
@@ -47,8 +48,8 @@ Deno.serve(async (req) => {
     if (/[,;\s]/.test(email)) {
       return jsonResponse({ ok: false, error: "Only one email address allowed" }, 400);
     }
-    if (!Array.isArray(games) || games.length === 0 || games.length > 3) {
-      return jsonResponse({ ok: false, error: "Must have 1-3 games" }, 400);
+    if (!Array.isArray(games) || games.length === 0 || games.length > MAX_PICKS) {
+      return jsonResponse({ ok: false, error: `Must have 1-${MAX_PICKS} games` }, 400);
     }
 
     // Validate each game
@@ -86,7 +87,7 @@ Deno.serve(async (req) => {
     // --- Check for existing config ---
     const { data: existing } = await supabase
       .from("alert_configs")
-      .select("email, games_locked")
+      .select("email, games, games_locked")
       .eq("license_hash", licenseHash)
       .maybeSingle();
 
@@ -99,8 +100,34 @@ Deno.serve(async (req) => {
         );
       }
 
-      // Update games preferences only
-      // (game selections are already locked, but price thresholds can change)
+      // Per-pick lock enforcement: every match_number that was previously saved
+      // must still be present (no removal) and must keep the same performance_id
+      // (no swap). New match_numbers can be added freely up to MAX_PICKS.
+      const existingGames: any[] = existing.games || [];
+      const existingByMatch = new Map<number, any>();
+      for (const g of existingGames) existingByMatch.set(g.match_number, g);
+      const incomingMatchNumbers = new Set<number>(games.map((g: any) => g.match_number));
+
+      for (const lockedMatch of existingByMatch.keys()) {
+        if (!incomingMatchNumbers.has(lockedMatch)) {
+          return jsonResponse(
+            { ok: false, error: `Cannot remove locked pick #${lockedMatch}` },
+            403
+          );
+        }
+      }
+      for (const incoming of games) {
+        const locked = existingByMatch.get(incoming.match_number);
+        if (locked && locked.performance_id !== incoming.performance_id) {
+          return jsonResponse(
+            { ok: false, error: `Cannot change performance_id of locked pick #${incoming.match_number}` },
+            403
+          );
+        }
+      }
+
+      // expires_at intentionally NOT touched on update — TTL stays frozen
+      // from the original insert.
       const { error: updateError } = await supabase
         .from("alert_configs")
         .update({
@@ -120,10 +147,11 @@ Deno.serve(async (req) => {
         .insert({ license_hash: licenseHash, email, games, action: "update" });
       if (historyError) console.error("history update error:", historyError);
 
-      return jsonResponse({ ok: true, gamesLocked: true });
+      return jsonResponse({ ok: true, gamesLocked: true, maxPicks: MAX_PICKS });
     }
 
     // --- Insert new config ---
+    // expires_at uses the SQL column DEFAULT (now() + interval '180 days').
     const { error: insertError } = await supabase.from("alert_configs").insert({
       license_hash: licenseHash,
       email,
@@ -142,7 +170,7 @@ Deno.serve(async (req) => {
       .insert({ license_hash: licenseHash, email, games, action: "insert" });
     if (historyError) console.error("history insert error:", historyError);
 
-    return jsonResponse({ ok: true, gamesLocked: true });
+    return jsonResponse({ ok: true, gamesLocked: true, maxPicks: MAX_PICKS });
   } catch (err) {
     console.error("save-alerts error:", err);
     return jsonResponse({ ok: false, error: "Server error" }, 500);

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -69,7 +69,10 @@ CREATE TABLE alert_configs (
   games           jsonb NOT NULL,
   games_locked    boolean DEFAULT true,
   created_at      timestamptz DEFAULT now(),
-  updated_at      timestamptz DEFAULT now()
+  updated_at      timestamptz DEFAULT now(),
+  -- TTL for the alert config. Set on insert, never updated. To change later:
+  --   ALTER TABLE alert_configs ALTER COLUMN expires_at SET DEFAULT (now() + interval '14 days');
+  expires_at      timestamptz NOT NULL DEFAULT (now() + interval '180 days')
 );
 
 CREATE INDEX idx_alert_configs_license ON alert_configs (license_hash);


### PR DESCRIPTION
## Summary

Syncs 6 commits from the private repo covering tonight's April 14 work:

- **b7b89b3** Salvage scans on per-seat anomalies — clamp prices, drop bad seats
- **c7c75ea** Capture contingentId, seatQuality, and extent for seat preselect bridge
- **5d52372** Clarify scan state in popup — stuck-help block + SCANNING/SCANNED badge
- **9aeeedd** Alerts: per-pick locking, centralized MAX_PICKS, expires_at TTL
- **462a1ba** Document April 14 changes in CHANGELOG
- **b26f759** Bump version to 2.1.1

## Highlights

- **Alerts fix**: saving with 1 or 2 picks no longer hides the match browser — users can top off the remaining slots later. Per-pick locking replaces the all-or-nothing \`games_locked\` flag. Server-side enforces no removal / no performance_id swap of locked picks.
- **ingest-scan resilience**: one anomalous seat no longer rejects the entire scan. Prices above int4 max get clamped, sub-\$1 / non-numeric prices are nulled, oversized strings are truncated, bad seat IDs are dropped.
- **Scanner tab UX honesty**: "LIVE" pulsing badge replaced with static SCANNING/SCANNED that actually tracks scan state. New stuck-help block points users at the BUY TICKETS → BUY → game workaround.
- **expires_at TTL**: new column on \`alert_configs\`, 180-day default, frozen on update. Migration ran separately in the Supabase SQL Editor.
- **MAX_PICKS centralized**: single constant in new \`_shared/alert_constants.ts\` returned from both Edge Functions; popup auto-syncs.
- **Extension version**: 2.1.0 → 2.1.1

Full changelog entries are in the \`CHANGELOG.md\` diff.

## Test plan

- [ ] Edge Functions deployed (\`supabase functions deploy ingest-scan save-alerts get-alerts\`)
- [ ] SQL migration run in Supabase Dashboard (\`ALTER TABLE alert_configs ADD COLUMN expires_at ...\` + backfill)
- [ ] Unpacked extension reloaded
- [ ] Alerts tab: save 1 pick → 2 empty slots + browser still visible → add 2nd → confirm dialog → save → add 3rd → slots full
- [ ] Threshold-only edit on locked pick: no confirm dialog, button reads "Update Price Thresholds"
- [ ] Scanner tab: badge reads "SCANNED" on matches with data, flips to "SCANNING" during an active scan
- [ ] ingest-scan POST no longer returns 400 for scans containing VIP-tier seats

🤖 Generated with [Claude Code](https://claude.com/claude-code)